### PR TITLE
fix voice name not fitting standard

### DIFF
--- a/lib/src/google/voices/voice_model.dart
+++ b/lib/src/google/voices/voice_model.dart
@@ -51,9 +51,13 @@ class VoiceGoogle extends VoiceUniversal {
   factory VoiceGoogle.fromJson(Map<String, dynamic> json) =>
       _$VoiceGoogleFromJson(json);
 
-  static List<String> _toEngines(String name) {
-    List<String> nameSegments = name.split('-');
-    return [nameSegments[2].toLowerCase()];
+   static List<String> _toEngines(String name) {
+    if (name.contains('-')) {
+      List<String> nameSegments = name.split('-');
+      return [nameSegments[2].toLowerCase()];
+    } else {
+      return [name.toLowerCase()];
+    }
   }
 
   static String _toGender(String ssmlGender) {


### PR DESCRIPTION
some newer voices do not fit the old standard and need a separate handling (see Aoede, Fenrir, Leda and Orus at https://cloud.google.com/text-to-speech/docs/voices)